### PR TITLE
Revert "Updated subprotocols behavior"

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -224,14 +224,10 @@ def test_send_after_protocol_close(protocol_cls):
 
 
 @pytest.mark.parametrize("protocol_cls", [HttpToolsProtocol, H11Protocol])
-@pytest.mark.parametrize("acceptable_subprotocol", ["proto1", "proto2"])
-def test_subprotocols(protocol_cls, acceptable_subprotocol):
+def test_subprotocols(protocol_cls):
     class App(WebSocketResponse):
         async def websocket_connect(self, message):
-            if acceptable_subprotocol in self.scope["subprotocols"]:
-                await self.send({"type": "websocket.accept", "subprotocol": acceptable_subprotocol})
-            else:
-                await self.send({"type": "websocket.close"})
+            await self.send({"type": "websocket.accept", "subprotocol": "proto1"})
 
     async def get_subprotocol(url):
         async with websockets.connect(
@@ -242,5 +238,5 @@ def test_subprotocols(protocol_cls, acceptable_subprotocol):
     with run_server(App, protocol_cls=protocol_cls) as url:
         loop = asyncio.new_event_loop()
         subprotocol = loop.run_until_complete(get_subprotocol(url))
-        assert subprotocol == acceptable_subprotocol
+        assert subprotocol == "proto1"
         loop.close()

--- a/uvicorn/protocols/websockets/websockets.py
+++ b/uvicorn/protocols/websockets/websockets.py
@@ -24,12 +24,9 @@ def websocket_upgrade(http):
         return
 
     # Retrieve any subprotocols to be negotiated with the consumer later
-    subprotocols = []
-    for header_key, header_value in http.headers:
-        if header_key != b"sec-websocket-protocol":
-            continue
-        for subprotocol in header_value.split(b","):
-            subprotocols.append(subprotocol.decode("ascii").strip())
+    subprotocols = request_headers.get(b"sec-websocket-protocol", None)
+    if subprotocols:
+        subprotocols = subprotocols.split(b",")
     http.scope.update({"type": "websocket", "subprotocols": subprotocols})
     asgi_instance = http.app(http.scope)
     request = WebSocketRequest(http, response_headers)


### PR DESCRIPTION
Reverts encode/uvicorn#127

Builds have started failing since that PR.

I don't *think* that it's actually the issue, since it passed the tests, and it's only since the merge-to-master that it's started failing, but let's see if they run properly against a revert....