### PR TITLE
Fix typo in deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ xfail_strict=True
 filterwarnings=
     # Turn warnings that aren't filtered into exceptions
     error
-    ignore: \"watchgod\" is depreciated\, you should switch to watchfiles \(`pip install watchfiles`\)\.:DeprecationWarning
+    ignore: \"watchgod\" is deprecated\, you should switch to watchfiles \(`pip install watchfiles`\)\.:DeprecationWarning
     ignore: Uvicorn's native WSGI implementation is deprecated, you should switch to a2wsgi \(`pip install a2wsgi`\)\.:DeprecationWarning
     ignore: 'cgi' is deprecated and slated for removal in Python 3\.13:DeprecationWarning
 

--- a/uvicorn/supervisors/watchgodreload.py
+++ b/uvicorn/supervisors/watchgodreload.py
@@ -131,7 +131,7 @@ class WatchGodReload(BaseReload):
         sockets: List[socket],
     ) -> None:
         warnings.warn(
-            '"watchgod" is depreciated, you should switch '
+            '"watchgod" is deprecated, you should switch '
             "to watchfiles (`pip install watchfiles`).",
             DeprecationWarning,
         )


### PR DESCRIPTION
I think it was supposed to be `deprecated` instead of `depreciated` in the warning.