### PR TITLE
add timeout_worker_is_alive as an option for main.run.

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -112,6 +112,9 @@ Options:
   --timeout-graceful-shutdown INTEGER
                                   Maximum number of seconds to wait for
                                   graceful shutdown.
+  --timeout-worker-is-alive FLOAT
+                                  Maximum number of seconds to wait for
+                                  judging if a worker process is alive.
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,6 +182,9 @@ Options:
   --timeout-graceful-shutdown INTEGER
                                   Maximum number of seconds to wait for
                                   graceful shutdown.
+  --timeout-worker-is-alive FLOAT
+                                  Maximum number of seconds to wait for
+                                  judging if a worker process is alive.
   --ssl-keyfile TEXT              SSL key file
   --ssl-certfile TEXT             SSL certificate file
   --ssl-keyfile-password TEXT     SSL keyfile password

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -212,6 +212,7 @@ class Config:
         timeout_keep_alive: int = 5,
         timeout_notify: int = 30,
         timeout_graceful_shutdown: int | None = None,
+        timeout_worker_is_alive: float = 5,
         callback_notify: Callable[..., Awaitable[None]] | None = None,
         ssl_keyfile: str | None = None,
         ssl_certfile: str | os.PathLike[str] | None = None,
@@ -256,6 +257,7 @@ class Config:
         self.timeout_keep_alive = timeout_keep_alive
         self.timeout_notify = timeout_notify
         self.timeout_graceful_shutdown = timeout_graceful_shutdown
+        self.timeout_worker_is_alive = timeout_worker_is_alive
         self.callback_notify = callback_notify
         self.ssl_keyfile = ssl_keyfile
         self.ssl_certfile = ssl_certfile

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -280,6 +280,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     default=None,
     help="Maximum number of seconds to wait for graceful shutdown.",
 )
+@click.option(
+    "--timeout-worker-is-alive",
+    type=float,
+    default=5,
+    help="Maximum number of seconds to wait for judging if a worker process is alive.",
+)
 @click.option("--ssl-keyfile", type=str, default=None, help="SSL key file", show_default=True)
 @click.option(
     "--ssl-certfile",
@@ -394,6 +400,7 @@ def main(
     limit_max_requests: int,
     timeout_keep_alive: int,
     timeout_graceful_shutdown: int | None,
+    timeout_worker_is_alive: float,
     ssl_keyfile: str,
     ssl_certfile: str,
     ssl_keyfile_password: str,
@@ -443,6 +450,7 @@ def main(
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
         timeout_graceful_shutdown=timeout_graceful_shutdown,
+        timeout_worker_is_alive=timeout_worker_is_alive,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         ssl_keyfile_password=ssl_keyfile_password,
@@ -495,6 +503,7 @@ def run(
     limit_max_requests: int | None = None,
     timeout_keep_alive: int = 5,
     timeout_graceful_shutdown: int | None = None,
+    timeout_worker_is_alive: float = 5,
     ssl_keyfile: str | None = None,
     ssl_certfile: str | os.PathLike[str] | None = None,
     ssl_keyfile_password: str | None = None,
@@ -547,6 +556,7 @@ def run(
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
         timeout_graceful_shutdown=timeout_graceful_shutdown,
+        timeout_worker_is_alive=timeout_worker_is_alive,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         ssl_keyfile_password=ssl_keyfile_password,

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -164,7 +164,7 @@ class Multiprocess:
             return  # parent process is exiting, no need to keep subprocess alive
 
         for idx, process in enumerate(self.processes):
-            if process.is_alive():
+            if process.is_alive(timeout=self.config.timeout_worker_is_alive):
                 continue
 
             process.kill()  # process is hung, kill it


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

The option lets users set the timeout for judging if a process is dead in multiprocessing mode(i.e., workers > 1).
When the module calls uvicorn.run has some heavy load like importing a lot of modules, the is_alive check in supervisors.multiprocessing may be blocked. When this happens, the default 5 seconds timeout may cause the misjudgement of a process and kill it.
Issues like https://github.com/encode/uvicorn/discussions/2396 , https://stackoverflow.com/questions/78680384/during-uvicorn-startup-child-process-dies-in-kubernetes-cluster may be caused by the case.


# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
