### PR TITLE
refine help message for option --proxy-headers

### DIFF
--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -223,7 +223,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--proxy-headers/--no-proxy-headers",
     is_flag=True,
     default=True,
-    help="Enable/Disable X-Forwarded-Proto, X-Forwarded-For, X-Forwarded-Port to populate remote address info.",
+    help="Enable/Disable X-Forwarded-Proto, X-Forwarded-For to populate url scheme and remote address info.",
 )
 @click.option(
     "--server-header/--no-server-header",


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->
This is a follow-up PR fixing document, per discussion at https://github.com/encode/uvicorn/issues/1974#issuecomment-3009167170.

`ProxyHeadersMiddleware` is not making use of `X-Forwarded-Port` header. `X-Forwarded-Port` header contains the listening port of the reverse proxy (usually a load balancer). `X-Forwarded-Port` header does not contain the client's source TCP port, thus should not be used to populate source address.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
