### PR TITLE
Add parameter `--timeout-process-probing` for computationally intensive tasks

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -146,3 +146,4 @@ To understand more about the SSL context options, please refer to the [Python do
 
 * `--timeout-keep-alive <int>` - Close Keep-Alive connections if no new data is received within this timeout. **Default:** *5*.
 * `--timeout-graceful-shutdown <int>` - Maximum number of seconds to wait for graceful shutdown. After this timeout, the server will start terminating requests.
+* `--timeout-process-probing` - Maximum number of seconds to wait for a child process to become alive. After this timeout, the main process will terminate the child process and then spawn a new child process.

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -95,40 +95,6 @@ def test_multiprocess_health_check() -> None:
     supervisor.join_all()
 
 
-def computation_intensive_process(sockets: list[socket.socket] | None) -> None:
-    data = [1] * 2000000000
-    while True:  # pragma: no cover
-        json.dumps(data)
-        time.sleep(0.5)
-
-
-@new_console_in_windows
-def test_computation_intensive_multiprocess_health_check() -> None:
-    """
-    Ensure that health checks run as expected in computationally intensive scenarios.
-    """
-
-    def get_pids(target, timeout):
-        config = Config(app=app, workers=1, timeout_process_probing=timeout)
-        supervisor = Multiprocess(config, target=target, sockets=[])
-        supervisor.init_processes()
-        time.sleep(0.5)
-
-        pid1 = supervisor.processes[0].pid
-        supervisor.keep_subprocess_alive()
-        pid2 = supervisor.processes[0].pid
-
-        supervisor.terminate_all()
-        supervisor.join_all()
-        return (pid1, pid2)
-
-    pid1, pid2 = get_pids(target=computation_intensive_process, timeout=2)
-    assert pid1 != pid2
-
-    pid1, pid2 = get_pids(target=computation_intensive_process, timeout=12)
-    assert pid1 == pid2
-
-
 @new_console_in_windows
 def test_multiprocess_sigterm() -> None:
     """

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import functools
+import json
 import os
 import signal
 import socket
 import threading
 import time
-import json
 from typing import Any, Callable
 
 import pytest

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import json
 import os
 import signal
 import socket

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -8,7 +8,6 @@ import threading
 import time
 import json
 from typing import Any, Callable
-from multiprocessing import Barrier
 
 import pytest
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -97,11 +97,11 @@ def test_multiprocess_health_check() -> None:
 
 
 def computation_intensive_process(sockets: list[socket.socket] | None) -> None:
-    data = [1] * 200000000
+    data = [1] * 2000000000
     while True:  # pragma: no cover
-        json.dumps(data)  # about 7s
+        json.dumps(data)
         time.sleep(0.5)
-        
+
 
 @new_console_in_windows
 def test_computation_intensive_multiprocess_health_check() -> None:
@@ -113,7 +113,7 @@ def test_computation_intensive_multiprocess_health_check() -> None:
         config = Config(app=app, workers=1, timeout_process_probing=timeout)
         supervisor = Multiprocess(config, target=target, sockets=[])
         supervisor.init_processes()
-        time.sleep(1)
+        time.sleep(0.5)
 
         pid1 = supervisor.processes[0].pid
         supervisor.keep_subprocess_alive()

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -213,6 +213,7 @@ class Config:
         backlog: int = 2048,
         timeout_keep_alive: int = 5,
         timeout_notify: int = 30,
+        timeout_process_probing: int = 5,
         timeout_graceful_shutdown: int | None = None,
         callback_notify: Callable[..., Awaitable[None]] | None = None,
         ssl_keyfile: str | os.PathLike[str] | None = None,
@@ -257,6 +258,7 @@ class Config:
         self.backlog = backlog
         self.timeout_keep_alive = timeout_keep_alive
         self.timeout_notify = timeout_notify
+        self.timeout_process_probing = timeout_process_probing
         self.timeout_graceful_shutdown = timeout_graceful_shutdown
         self.callback_notify = callback_notify
         self.ssl_keyfile = ssl_keyfile

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -285,6 +285,12 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     default=None,
     help="Maximum number of seconds to wait for graceful shutdown.",
 )
+@click.option(
+    "--timeout-process-probing",
+    type=int,
+    default=5,
+    help="Maximum number of seconds to wait for a child process to become alive.",
+)
 @click.option("--ssl-keyfile", type=str, default=None, help="SSL key file", show_default=True)
 @click.option(
     "--ssl-certfile",
@@ -399,6 +405,7 @@ def main(
     limit_max_requests: int,
     timeout_keep_alive: int,
     timeout_graceful_shutdown: int | None,
+    timeout_process_probing: int,
     ssl_keyfile: str,
     ssl_certfile: str,
     ssl_keyfile_password: str,
@@ -448,6 +455,7 @@ def main(
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
         timeout_graceful_shutdown=timeout_graceful_shutdown,
+        timeout_process_probing=timeout_process_probing,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         ssl_keyfile_password=ssl_keyfile_password,
@@ -500,6 +508,7 @@ def run(
     limit_max_requests: int | None = None,
     timeout_keep_alive: int = 5,
     timeout_graceful_shutdown: int | None = None,
+    timeout_process_probing: int = 5,
     ssl_keyfile: str | os.PathLike[str] | None = None,
     ssl_certfile: str | os.PathLike[str] | None = None,
     ssl_keyfile_password: str | None = None,
@@ -552,6 +561,7 @@ def run(
         limit_max_requests=limit_max_requests,
         timeout_keep_alive=timeout_keep_alive,
         timeout_graceful_shutdown=timeout_graceful_shutdown,
+        timeout_process_probing=timeout_process_probing,
         ssl_keyfile=ssl_keyfile,
         ssl_certfile=ssl_certfile,
         ssl_keyfile_password=ssl_keyfile_password,

--- a/uvicorn/supervisors/multiprocess.py
+++ b/uvicorn/supervisors/multiprocess.py
@@ -112,6 +112,7 @@ class Multiprocess:
 
         self.processes_num = config.workers
         self.processes: list[Process] = []
+        self.timeout_process_probing = config.timeout_process_probing
 
         self.should_exit = threading.Event()
 
@@ -164,7 +165,7 @@ class Multiprocess:
             return  # parent process is exiting, no need to keep subprocess alive
 
         for idx, process in enumerate(self.processes):
-            if process.is_alive():
+            if process.is_alive(self.timeout_process_probing):
                 continue
 
             process.kill()  # process is hung, kill it


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

When the child process is a computationally intensive task, the heartbeat thread (pong) of the child process will be preempted of its CPU time slice, resulting in process heartbeat failure and restart. Therefore, it is necessary to increase the heartbeat timeout between processes.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
