### PR TITLE
Update server.py

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -217,7 +217,7 @@ class Server:
                 message,
                 protocol_name,
                 host,
-                port,
+                int(port),
                 extra={"color_message": color_message},
             )
 


### PR DESCRIPTION
Without this, if we pass the port as a string, we get a bunch of errors because the log format %d expects a digit.
<img width="1169" height="687" alt="image" src="https://github.com/user-attachments/assets/210000ca-9fae-4071-b9aa-c9d8ef6776ec" />
<img width="923" height="656" alt="image" src="https://github.com/user-attachments/assets/dd1d5c74-69ef-4962-a8a7-73bac7227e85" />
