### PR TITLE
fix: add `exc_info` to log if `h11.RemoteProtocolError` occurs

### DIFF
--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -175,9 +175,9 @@ class H11Protocol(asyncio.Protocol):
         while True:
             try:
                 event = self.conn.next_event()
-            except h11.RemoteProtocolError:
+            except h11.RemoteProtocolError as e:
                 msg = "Invalid HTTP request received."
-                self.logger.warning(msg)
+                self.logger.warning(msg, exc_info=e)
                 self.send_400_response(msg)
                 return
 


### PR DESCRIPTION
As asked in <https://github.com/Kludex/uvicorn/2650> this hides errors like too large headers.
The only log that is emited is `Invalid HTTP request received.`.


