### PR TITLE
Do not raise "Bad file description" on nested multiprocess

### DIFF
--- a/uvicorn/_subprocess.py
+++ b/uvicorn/_subprocess.py
@@ -70,7 +70,11 @@ def subprocess_started(
     """
     # Re-open stdin.
     if stdin_fileno is not None:
-        sys.stdin = os.fdopen(stdin_fileno)  # pragma: full coverage
+        try:
+            sys.stdin = os.fdopen(stdin_fileno)
+        except OSError:
+            # `stdin_fileno` may not be valid in nested multiprocessing scenarios
+            pass
 
     # Logging needs to be setup again for each child.
     config.configure_logging()


### PR DESCRIPTION
Is this what you mean in https://github.com/Kludex/uvicorn/issues/2679 @mattp-?

Is your point that we don't need the logic to pass the `stdin_fileno` around?