### PR TITLE
feat(logging): add customizable access log format for Gunicorn style …

### DIFF
--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -212,3 +212,46 @@ async def test_server_start_with_port_zero(caplog: pytest.LogCaptureFixture):
         host, port = sock.getsockname()
     messages = [record.message for record in caplog.records if "uvicorn" in record.name]
     assert f"Uvicorn running on http://{host}:{port} (Press CTRL+C to quit)" in messages
+
+
+async def test_gunicorn_access_log_format(unused_tcp_port: int, capsys: pytest.CaptureFixture[str]) -> None:
+    """Test access logging with Gunicorn format."""
+    config = Config(
+        app=app,
+        access_log_format='%(h)s "%(r)s" %(s)s %(b)s',
+        http="h11",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+
+    assert response.status_code == 204
+    captured = capsys.readouterr()
+    # Check Gunicorn format is used in stdout
+    assert "127.0.0.1" in captured.out
+    assert '"GET / HTTP/1.1"' in captured.out
+    assert " 204 " in captured.out
+    assert " -" in captured.out  # This is the %(b)s part (response size is None -> "-")
+
+
+@pytest.mark.anyio
+async def test_gunicorn_access_log_format_httptools(unused_tcp_port: int, capsys: pytest.CaptureFixture[str]) -> None:
+    """Test access logging with Gunicorn format using httptools."""
+    config = Config(
+        app=app,
+        access_log_format='%(h)s "%(r)s" %(s)s %(b)s',
+        http="httptools",
+        port=unused_tcp_port,
+    )
+    async with run_server(config):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}")
+
+    assert response.status_code == 204
+    captured = capsys.readouterr()
+    # Check Gunicorn format is used in stdout
+    assert "127.0.0.1" in captured.out
+    assert '"GET / HTTP/1.1"' in captured.out
+    assert " 204 " in captured.out
+    assert " -" in captured.out  # This is the %(b)s part (response size is None -> "-")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import os
+from typing import Any
+
+import pytest
+
+from uvicorn.logging import AccessFormatter, GunicornAccessFormatter
+
+pytestmark = pytest.mark.anyio
+
+
+def test_basic_access_formatter() -> None:
+    """Test basic access log formatting."""
+    formatter = AccessFormatter(fmt='%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s')
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(formatter)
+
+    logger = logging.getLogger("test_access")
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    logger.info(
+        '%s - "%s %s HTTP/%s" %d',
+        "192.168.1.1:12345",
+        "GET",
+        "/test",
+        "1.1",
+        200,
+    )
+    output = stream.getvalue()
+
+    assert "192.168.1.1:12345" in output
+    assert "GET /test HTTP/1.1" in output
+    assert "200" in output
+
+
+def format_log(fmt: str, scope: dict[str, Any], status: int, response_time: float, response_size: int | None) -> str:
+    """Helper to format a log entry using GunicornAccessFormatter."""
+    formatter = GunicornAccessFormatter(fmt=fmt, use_colors=False)
+
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="",
+        args=(scope, status, response_time, response_size),
+        exc_info=None,
+    )
+
+    return formatter.format(record)
+
+
+def create_scope(
+    method: str = "GET",
+    path: str = "/test",
+    query_string: bytes = b"foo=bar",
+    client: tuple[str, int] | None = ("192.168.1.100", 12345),
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> dict[str, Any]:
+    """Create a test ASGI scope."""
+    if headers is None:
+        headers = [
+            (b"host", b"localhost:8000"),
+            (b"user-agent", b"TestClient/1.0"),
+            (b"referer", b"http://example.com/"),
+        ]
+
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "query_string": query_string,
+        "root_path": "",
+        "headers": headers,
+        "server": ("localhost", 8000),
+        "client": client,
+    }
+
+
+def test_remote_address_atom() -> None:
+    scope = create_scope(client=("10.0.0.5", 54321))
+    output = format_log("%(h)s", scope, 200, 0.123, 1024)
+    assert output == "10.0.0.5"
+
+
+def test_remote_logname_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(l)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_username_atom_without_auth() -> None:
+    scope = create_scope()
+    output = format_log("%(u)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_username_atom_with_basic_auth() -> None:
+    credentials = "admin:password"
+    encoded = base64.b64encode(credentials.encode()).decode()
+    headers = [(b"authorization", f"Basic {encoded}".encode())]
+    scope = create_scope(headers=headers)
+    output = format_log("%(u)s", scope, 200, 0.123, 1024)
+    assert output == "admin"
+
+
+def test_username_atom_with_special_chars() -> None:
+    credentials = "user@example.com:password123"
+    encoded = base64.b64encode(credentials.encode()).decode()
+    headers = [(b"authorization", f"Basic {encoded}".encode())]
+    scope = create_scope(headers=headers)
+    output = format_log("%(u)s", scope, 200, 0.123, 1024)
+    assert output == "user@example.com"
+
+
+def test_username_atom_with_invalid_auth() -> None:
+    headers = [(b"authorization", b"Basic invalid!!!")]
+    scope = create_scope(headers=headers)
+    output = format_log("%(u)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_username_atom_with_bearer_token() -> None:
+    headers = [(b"authorization", b"Bearer eyJhbGci...")]
+    scope = create_scope(headers=headers)
+    output = format_log("%(u)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_timestamp_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(t)s", scope, 200, 0.123, 1024)
+    # Should be in format [DD/Mon/YYYY:HH:MM:SS +ZZZZ]
+    assert output.startswith("[")
+    assert output.endswith("]")
+    assert "/" in output
+    assert ":" in output
+
+
+def test_request_line_atom() -> None:
+    scope = create_scope(method="POST", path="/api/users", query_string=b"page=1")
+    output = format_log("%(r)s", scope, 200, 0.123, 1024)
+    # May contain ANSI codes with colors, so just check main parts
+    assert "POST" in output
+    assert "/api/users?page=1" in output
+    assert "HTTP/1.1" in output
+
+
+def test_method_atom() -> None:
+    scope = create_scope(method="DELETE")
+    output = format_log("%(m)s", scope, 204, 0.123, 0)
+    assert output == "DELETE"
+
+
+def test_url_path_atom() -> None:
+    scope = create_scope(path="/api/users/123", query_string=b"foo=bar")
+    output = format_log("%(U)s", scope, 200, 0.123, 1024)
+    assert output == "/api/users/123"
+
+
+def test_query_string_atom() -> None:
+    scope = create_scope(query_string=b"page=1&limit=10")
+    output = format_log("%(q)s", scope, 200, 0.123, 1024)
+    assert output == "page=1&limit=10"
+
+
+def test_query_string_atom_empty() -> None:
+    scope = create_scope(query_string=b"")
+    output = format_log("%(q)s", scope, 200, 0.123, 1024)
+    assert output == ""
+
+
+def test_protocol_atom() -> None:
+    scope = create_scope()
+    scope["http_version"] = "2.0"
+    output = format_log("%(H)s", scope, 200, 0.123, 1024)
+    assert output == "2.0"
+
+
+def test_status_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(s)s", scope, 404, 0.123, 1024)
+    assert output == "404"
+
+
+def test_response_length_bytes_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(B)s", scope, 200, 0.123, 2048)
+    assert output == "2048"
+
+
+def test_response_length_bytes_atom_zero() -> None:
+    scope = create_scope()
+    output = format_log("%(B)s", scope, 204, 0.123, 0)
+    assert output == "0"
+
+
+def test_response_length_clf_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(b)s", scope, 200, 0.123, 1024)
+    assert output == "1024"
+
+
+def test_response_length_clf_atom_zero() -> None:
+    scope = create_scope()
+    output = format_log("%(b)s", scope, 204, 0.123, 0)
+    assert output == "-"
+
+
+def test_response_length_clf_atom_none() -> None:
+    scope = create_scope()
+    output = format_log("%(b)s", scope, 204, 0.123, None)
+    assert output == "-"
+
+
+def test_referer_atom() -> None:
+    headers = [(b"referer", b"https://example.com/page")]
+    scope = create_scope(headers=headers)
+    output = format_log("%(f)s", scope, 200, 0.123, 1024)
+    assert output == "https://example.com/page"
+
+
+def test_referer_atom_missing() -> None:
+    scope = create_scope(headers=[])
+    output = format_log("%(f)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_user_agent_atom() -> None:
+    headers = [(b"user-agent", b"Mozilla/5.0 (X11; Linux x86_64)")]
+    scope = create_scope(headers=headers)
+    output = format_log("%(a)s", scope, 200, 0.123, 1024)
+    assert output == "Mozilla/5.0 (X11; Linux x86_64)"
+
+
+def test_user_agent_atom_missing() -> None:
+    scope = create_scope(headers=[])
+    output = format_log("%(a)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_response_time_seconds_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(T)s", scope, 200, 1.234567, 1024)
+    assert output == "1"
+
+
+def test_response_time_microseconds_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(D)s", scope, 200, 0.123456, 1024)
+    # 0.123456 seconds = 123456 microseconds
+    assert output == "123456"
+
+
+def test_response_time_milliseconds_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(M)s", scope, 200, 1.234567, 1024)
+    # 1.234567 seconds = 1234 milliseconds
+    assert output == "1234"
+
+
+def test_response_time_decimal_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(L)s", scope, 200, 1.234567, 1024)
+    assert output == "1.234567"
+
+
+def test_process_id_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(p)s", scope, 200, 0.123, 1024)
+    assert output == str(os.getpid())
+
+
+def test_request_header_atom() -> None:
+    headers = [(b"host", b"example.com:8080")]
+    scope = create_scope(headers=headers)
+    output = format_log("%({host}i)s", scope, 200, 0.123, 1024)
+    assert output == "example.com:8080"
+
+
+def test_request_header_atom_custom() -> None:
+    headers = [(b"x-request-id", b"abc-123-def")]
+    scope = create_scope(headers=headers)
+    output = format_log("%({x-request-id}i)s", scope, 200, 0.123, 1024)
+    assert output == "abc-123-def"
+
+
+def test_request_header_atom_missing() -> None:
+    scope = create_scope(headers=[])
+    output = format_log("%({x-missing}i)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_response_header_atom() -> None:
+    scope = create_scope()
+    output = format_log("%({content-type}o)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_common_log_format() -> None:
+    fmt = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s'
+    scope = create_scope(method="GET", path="/test", query_string=b"")
+    output = format_log(fmt, scope, 200, 0.123, 1024)
+
+    assert "192.168.1.100" in output
+    assert " - " in output
+    assert "GET /test HTTP/1.1" in output
+    assert " 200 " in output
+    assert " 1024" in output
+
+
+def test_combined_log_format() -> None:
+    fmt = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+    headers = [
+        (b"referer", b"http://example.com/"),
+        (b"user-agent", b"TestClient/1.0"),
+    ]
+    scope = create_scope(headers=headers)
+    output = format_log(fmt, scope, 200, 0.123, 1024)
+
+    assert "192.168.1.100" in output
+    assert "GET /test?foo=bar HTTP/1.1" in output
+    assert " 200 " in output
+    assert " 1024 " in output
+    assert '"http://example.com/"' in output
+    assert '"TestClient/1.0"' in output
+
+
+def test_combined_format_with_basic_auth() -> None:
+    fmt = '%(h)s - %(u)s [%(t)s] "%(r)s" %(s)s %(b)s'
+    credentials = "api_user:api_key"
+    encoded = base64.b64encode(credentials.encode()).decode()
+    headers = [(b"authorization", f"Basic {encoded}".encode())]
+    scope = create_scope(headers=headers)
+    output = format_log(fmt, scope, 201, 0.456, 5678)
+
+    assert "192.168.1.100 - api_user" in output
+    assert " 201 " in output
+    assert " 5678" in output
+
+
+def test_custom_format_with_timing() -> None:
+    fmt = "%(h)s [%(t)s] %(m)s %(U)s %(s)s %(D)s μs"
+    scope = create_scope(method="POST", path="/api/users", query_string=b"")
+    output = format_log(fmt, scope, 201, 0.123456, 2048)
+
+    assert "192.168.1.100" in output
+    assert "POST /api/users" in output
+    assert " 201 " in output
+    assert " 123456 μs" in output
+
+
+def test_format_with_multiple_headers() -> None:
+    fmt = "%(h)s %({host}i)s %({x-request-id}i)s %(s)s"
+    headers = [
+        (b"host", b"api.example.com"),
+        (b"x-request-id", b"req-12345"),
+    ]
+    scope = create_scope(headers=headers)
+    output = format_log(fmt, scope, 200, 0.123, 1024)
+
+    assert "192.168.1.100" in output
+    assert "api.example.com" in output
+    assert "req-12345" in output
+    assert " 200" in output
+
+
+def test_no_client_address() -> None:
+    scope = create_scope(client=None)
+    output = format_log("%(h)s", scope, 200, 0.123, 1024)
+    assert output == "-"
+
+
+def test_ipv6_client_address() -> None:
+    scope = create_scope(client=("::1", 54321))
+    output = format_log("%(h)s", scope, 200, 0.123, 1024)
+    assert output == "::1"
+
+
+def test_various_http_methods() -> None:
+    methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+    for method in methods:
+        scope = create_scope(method=method)
+        output = format_log("%(m)s", scope, 200, 0.123, 1024)
+        assert output == method
+
+
+def test_various_status_codes() -> None:
+    status_codes = [200, 201, 204, 301, 302, 304, 400, 401, 403, 404, 500, 502, 503]
+    for status in status_codes:
+        scope = create_scope()
+        output = format_log("%(s)s", scope, status, 0.123, 1024)
+        assert output == str(status)
+
+
+def test_root_path() -> None:
+    scope = create_scope(path="/", query_string=b"")
+    output = format_log("%(U)s", scope, 200, 0.123, 1024)
+    assert output == "/"
+
+
+def test_complex_query_string() -> None:
+    scope = create_scope(query_string=b"filter=active&sort=name&page=1&limit=50")
+    output = format_log("%(q)s", scope, 200, 0.123, 1024)
+    assert output == "filter=active&sort=name&page=1&limit=50"
+
+
+def test_very_small_response_time() -> None:
+    scope = create_scope()
+    output = format_log("%(D)s", scope, 200, 0.000001, 1024)
+    assert output == "1"
+
+
+def test_very_large_response_time() -> None:
+    scope = create_scope()
+    output = format_log("%(T)s", scope, 200, 10.5, 1024)
+    assert output == "10"
+
+
+def test_large_response_size() -> None:
+    scope = create_scope()
+    output = format_log("%(B)s", scope, 200, 0.123, 10485760)  # 10MB
+    assert output == "10485760"
+
+
+def test_header_case_insensitive() -> None:
+    headers = [
+        (b"host", b"example.com"),
+        (b"user-agent", b"TestClient"),
+    ]
+    scope = create_scope(headers=headers)
+    output = format_log("%({Host}i)s %({USER-AGENT}i)s", scope, 200, 0.123, 1024)
+    assert output == "example.com TestClient"
+
+
+def test_missing_format_atom() -> None:
+    scope = create_scope()
+    output = format_log("%(x)s", scope, 200, 0.123, 1024)
+    assert "<formatting error: missing atom" in output
+
+
+def test_default_format() -> None:
+    formatter = GunicornAccessFormatter(use_colors=False)
+    scope = create_scope()
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="",
+        args=(scope, 200, 0.123, 1024),
+        exc_info=None,
+    )
+    output = formatter.format(record)
+    # Default format is Combined Log Format
+    assert "192.168.1.100" in output
+    assert "GET /test?foo=bar HTTP/1.1" in output
+    assert " 200 " in output
+
+
+def test_empty_headers_list() -> None:
+    scope = create_scope(headers=[])
+    output = format_log("%({host}i)s %(f)s %(a)s", scope, 200, 0.123, 1024)
+    assert output == "- - -"
+
+
+def test_none_response_time() -> None:
+    scope = create_scope()
+    output = format_log("%(T)s %(D)s %(M)s %(L)s", scope, 200, None, 1024)
+    assert output == "0 0 0 0.000000"
+
+
+def test_formatter_with_logger() -> None:
+    formatter = GunicornAccessFormatter(
+        fmt='%(h)s - %(u)s [%(t)s] "%(r)s" %(s)s %(b)s',
+        use_colors=False,
+    )
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/users",
+        "query_string": b"page=1",
+        "http_version": "1.1",
+        "client": ("192.168.1.100", 12345),
+        "headers": [(b"host", b"localhost")],
+    }
+
+    # Create a LogRecord directly since using logger.info() causes premature formatting
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="",
+        args=(scope, 200, 0.123, 2048),
+        exc_info=None,
+    )
+
+    output = formatter.format(record)
+
+    assert "192.168.1.100" in output
+    assert "- -" in output  # No basic auth
+    assert '"GET /api/users?page=1 HTTP/1.1"' in output
+    assert " 200 " in output
+    assert " 2048" in output

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -40,7 +40,9 @@ def test_basic_access_formatter() -> None:
     assert "200" in output
 
 
-def format_log(fmt: str, scope: dict[str, Any], status: int, response_time: float, response_size: int | None) -> str:
+def format_log(
+    fmt: str, scope: dict[str, Any], status: int, response_time: float | None, response_size: int | None
+) -> str:
     """Helper to format a log entry using GunicornAccessFormatter."""
     formatter = GunicornAccessFormatter(fmt=fmt, use_colors=False)
 

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -196,6 +196,7 @@ class Config:
         log_config: dict[str, Any] | str | RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
         log_level: str | int | None = None,
         access_log: bool = True,
+        access_log_format: str | None = None,
         use_colors: bool | None = None,
         interface: InterfaceType = "auto",
         reload: bool = False,
@@ -245,6 +246,7 @@ class Config:
         self.log_config = log_config
         self.log_level = log_level
         self.access_log = access_log
+        self.access_log_format = access_log_format
         self.use_colors = use_colors
         self.interface = interface
         self.reload = reload
@@ -367,6 +369,13 @@ class Config:
                 if self.use_colors in (True, False):
                     self.log_config["formatters"]["default"]["use_colors"] = self.use_colors
                     self.log_config["formatters"]["access"]["use_colors"] = self.use_colors
+                # Apply access_log_format if specified
+                if self.access_log_format:
+                    self.log_config["formatters"]["access"] = {
+                        "()": "uvicorn.logging.GunicornAccessFormatter",
+                        "fmt": self.access_log_format,
+                        "use_colors": self.use_colors,
+                    }
                 logging.config.dictConfig(self.log_config)
             elif isinstance(self.log_config, str) and self.log_config.endswith(".json"):
                 with open(self.log_config) as file:

--- a/uvicorn/logging.py
+++ b/uvicorn/logging.py
@@ -189,7 +189,7 @@ class GunicornAccessFormatter(ColourizedFormatter):
         import binascii
         import os
         import re
-        from typing import Any, cast
+        from typing import Any, Optional, cast
 
         recordcopy = copy(record)
 
@@ -198,8 +198,8 @@ class GunicornAccessFormatter(ColourizedFormatter):
             args_tuple = cast(tuple[Any, ...], recordcopy.args)
             scope = cast(dict[str, Any], args_tuple[0])
             status_code = cast(int, args_tuple[1])
-            response_time = cast(float | None, args_tuple[2])
-            response_length = cast(int | None, args_tuple[3])
+            response_time = cast(Optional[float], args_tuple[2])
+            response_length = cast(Optional[int], args_tuple[3])
 
             method = cast(str, scope.get("method", ""))
             path = cast(str, scope.get("path", ""))

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -216,6 +216,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     help="Enable/Disable access log.",
 )
 @click.option(
+    "--access-log-format",
+    type=str,
+    default=None,
+    help="Access log format (gunicorn style). "
+    'Example: \'%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(D)s\'',
+)
+@click.option(
     "--use-colors/--no-use-colors",
     is_flag=True,
     default=None,
@@ -396,6 +403,7 @@ def main(
     log_config: str,
     log_level: str,
     access_log: bool,
+    access_log_format: str,
     proxy_headers: bool,
     server_header: bool,
     date_header: bool,
@@ -439,6 +447,7 @@ def main(
         log_config=LOGGING_CONFIG if log_config is None else log_config,
         log_level=log_level,
         access_log=access_log,
+        access_log_format=access_log_format,
         interface=interface,
         reload=reload,
         reload_dirs=reload_dirs or None,
@@ -499,6 +508,7 @@ def run(
     log_config: dict[str, Any] | str | RawConfigParser | IO[Any] | None = LOGGING_CONFIG,
     log_level: str | int | None = None,
     access_log: bool = True,
+    access_log_format: str | None = None,
     proxy_headers: bool = True,
     server_header: bool = True,
     date_header: bool = True,
@@ -552,6 +562,7 @@ def run(
         log_config=log_config,
         log_level=log_level,
         access_log=access_log,
+        access_log_format=access_log_format,
         proxy_headers=proxy_headers,
         server_header=server_header,
         date_header=date_header,

--- a/uvicorn/protocols/http/h11_impl.py
+++ b/uvicorn/protocols/http/h11_impl.py
@@ -572,4 +572,3 @@ class RequestResponseCycle:
         }
         self.body = b""
         return message
-        return message

--- a/uvicorn/protocols/http/httptools_impl.py
+++ b/uvicorn/protocols/http/httptools_impl.py
@@ -22,7 +22,7 @@ from uvicorn._types import (
 from uvicorn.config import Config
 from uvicorn.logging import TRACE_LOG_LEVEL
 from uvicorn.protocols.http.flow_control import CLOSE_HEADER, HIGH_WATER_LIMIT, FlowControl, service_unavailable
-from uvicorn.protocols.utils import get_client_addr, get_local_addr, get_path_with_query_string, get_remote_addr, is_ssl
+from uvicorn.protocols.utils import get_local_addr, get_remote_addr, is_ssl
 from uvicorn.server import ServerState
 
 HEADER_RE = re.compile(b'[\x00-\x1f\x7f()<>@,;:[]={} \t\\"]')
@@ -402,6 +402,12 @@ class RequestResponseCycle:
         self.response_complete = False
         self.chunked_encoding: bool | None = None
         self.expected_content_length = 0
+        self.response_size = 0
+
+        # Timing
+        import time
+
+        self.start_time = time.perf_counter()
 
     # ASGI exception wrapper
     async def run_asgi(self, app: ASGI3Application) -> None:
@@ -467,20 +473,11 @@ class RequestResponseCycle:
             self.waiting_for_100_continue = False
 
             status_code = message["status"]
+            self.status_code = status_code
             headers = self.default_headers + list(message.get("headers", []))
 
             if CLOSE_HEADER in self.scope["headers"] and CLOSE_HEADER not in headers:
                 headers = headers + [CLOSE_HEADER]
-
-            if self.access_log:
-                self.access_logger.info(
-                    '%s - "%s %s HTTP/%s" %d',
-                    get_client_addr(self.scope),
-                    self.scope["method"],
-                    get_path_with_query_string(self.scope),
-                    self.scope["http_version"],
-                    status_code,
-                )
 
             # Write response status line and headers
             content = [STATUS_LINE[status_code]]
@@ -519,6 +516,9 @@ class RequestResponseCycle:
             body = cast(bytes, message.get("body", b""))
             more_body = message.get("more_body", False)
 
+            # Track response size
+            self.response_size += len(body)
+
             # Write response body
             if self.scope["method"] == "HEAD":
                 self.expected_content_length = 0
@@ -544,6 +544,38 @@ class RequestResponseCycle:
                     raise RuntimeError("Response content shorter than Content-Length")
                 self.response_complete = True
                 self.message_event.set()
+
+                if self.access_log:
+                    import time
+
+                    from uvicorn.logging import GunicornAccessFormatter
+
+                    response_time = time.perf_counter() - self.start_time
+
+                    if (
+                        hasattr(self.access_logger, "handlers")
+                        and self.access_logger.handlers
+                        and isinstance(self.access_logger.handlers[0].formatter, GunicornAccessFormatter)
+                    ):
+                        self.access_logger.info(
+                            "",
+                            self.scope,
+                            self.status_code,
+                            response_time,
+                            self.response_size if self.response_size > 0 else None,
+                        )
+                    else:
+                        from uvicorn.protocols.utils import get_client_addr, get_path_with_query_string
+
+                        self.access_logger.info(
+                            '%s - "%s %s HTTP/%s" %d',
+                            get_client_addr(self.scope),
+                            self.scope["method"],
+                            get_path_with_query_string(self.scope),
+                            self.scope["http_version"],
+                            self.status_code,
+                        )
+
                 if not self.keep_alive:
                     self.transport.close()
                 self.on_response()


### PR DESCRIPTION
# Summary
This PR adds support for Gunicorn-style customizable access log formatting to Uvicorn, addressing issue #527 .

Users can now specify custom access log formats using the `--access-log-format` CLI option or the `access_log_format` parameter in the Python API, supporting 20+ format atoms compatible with Gunicorn's specification.

## Changes

- **New `GunicornAccessFormatter` class** in `uvicorn/logging.py`
  - Supports 20+ Gunicorn format atoms (h, l, u, t, r, m, U, q, H, s, B, b, f, a, T, D, M, L, p)
  - Basic Authentication username extraction
  - Request header interpolation via `%({header}i)s` syntax
  - Response time tracking in multiple units

- **CLI option `--access-log-format`** 
  - Example: `uvicorn app:app --access-log-format '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'`

- **Python API parameter `access_log_format`**
  - Added to `Config` class and `run()` function

- **Protocol integration**
  - Modified `h11_impl.py` and `httptools_impl.py` to track response time and size
  - Automatic formatter detection (GunicornAccessFormatter vs AccessFormatter)

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.