### PR TITLE
remove second path argument of ws_handler per websockets warning

### DIFF
--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -226,7 +226,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
         # itself (see https://github.com/Kludex/uvicorn/issues/920)
         self.handshake_started_event.set()
 
-    async def ws_handler(self, protocol: WebSocketServerProtocol, path: str) -> Any:  # type: ignore[override]
+    async def ws_handler(self, protocol: WebSocketServerProtocol) -> Any:  # type: ignore[override]
         """
         This is the main handler function for the 'websockets' implementation
         to call into. We just wait for close then return, and instead allow


### PR DESCRIPTION
# Summary

Regarding below warning
```
.venv\Lib\site-packages\websockets\legacy\server.py:1178: DeprecationWarning: remove second argument of ws_handler
  warnings.warn("remove second argument of ws_handler", DeprecationWarning)
```
just simply remove `path: str` argument

```py
# protocols/websockets/websockets_impl.py

## before
async def ws_handler(self, protocol: WebSocketServerProtocol, path: str) -> Any:  # type: ignore[override]

## after
async def ws_handler(self, protocol: WebSocketServerProtocol) -> Any:  # type: ignore[override]
```

Simple replicate the scenario using `flet`:

```sh
uv run flet create
uv run flet run --web
```

Before:
```sh
❯ uv run flet run --web
flet_app\.venv\Lib\site-packages\websockets\legacy\__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
  warnings.warn(  # deprecated in 14.0 - 2024-11-09
flet_app\.venv\Lib\site-packages\uvicorn\protocols\websockets\websockets_impl.py:17: DeprecationWarning: websockets.server.WebSocketServerProtocol is deprecated
  from websockets.server import WebSocketServerProtocol
http://127.0.0.1:57004
flet_app\.venv\Lib\site-packages\websockets\legacy\server.py:1178: DeprecationWarning: remove second argument of ws_handler
  warnings.warn("remove second argument of ws_handler", DeprecationWarning)
```

After
```sh
❯ uv run flet run --web
flet_app\.venv\Lib\site-packages\websockets\legacy\__init__.py:6: DeprecationWarning: websockets.legacy is deprecated; see https://websockets.readthedocs.io/en/stable/howto/upgrade.html for upgrade instructions
  warnings.warn(  # deprecated in 14.0 - 2024-11-09
http://127.0.0.1:53402
```

Since it seems more complicate to replace `WebSocketServerProtocol` with `ServerConnection` per upgrade instruction in https://websockets.readthedocs.io/en/stable/howto/upgrade.html, I'd like to propose this tiny change just for now. Thanks!

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
