### PR TITLE
Fix typo: error_occured -> error_occurred

### DIFF
--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -98,7 +98,7 @@ def test_lifespan_auto_with_error():
         lifespan = LifespanOn(config)
 
         await lifespan.startup()
-        assert lifespan.error_occured
+        assert lifespan.error_occurred
         assert not lifespan.should_exit
         await lifespan.shutdown()
 
@@ -117,7 +117,7 @@ def test_lifespan_on_with_error():
         lifespan = LifespanOn(config)
 
         await lifespan.startup()
-        assert lifespan.error_occured
+        assert lifespan.error_occurred
         assert lifespan.should_exit
         await lifespan.shutdown()
 
@@ -143,7 +143,7 @@ def test_lifespan_with_failed_startup(mode, raise_exception, caplog):
 
         await lifespan.startup()
         assert lifespan.startup_failed
-        assert lifespan.error_occured is raise_exception
+        assert lifespan.error_occurred is raise_exception
         assert lifespan.should_exit
         await lifespan.shutdown()
 
@@ -171,7 +171,7 @@ def test_lifespan_scope_asgi3app():
 
         await lifespan.startup()
         assert not lifespan.startup_failed
-        assert not lifespan.error_occured
+        assert not lifespan.error_occurred
         assert not lifespan.should_exit
         await lifespan.shutdown()
 
@@ -228,7 +228,7 @@ def test_lifespan_with_failed_shutdown(mode, raise_exception, caplog):
         assert not lifespan.startup_failed
         await lifespan.shutdown()
         assert lifespan.shutdown_failed
-        assert lifespan.error_occured is raise_exception
+        assert lifespan.error_occurred is raise_exception
         assert lifespan.should_exit
 
     loop = asyncio.new_event_loop()

--- a/uvicorn/lifespan/on.py
+++ b/uvicorn/lifespan/on.py
@@ -38,7 +38,7 @@ class LifespanOn:
         self.startup_event = asyncio.Event()
         self.shutdown_event = asyncio.Event()
         self.receive_queue: Queue[LifespanReceiveMessage] = asyncio.Queue()
-        self.error_occured = False
+        self.error_occurred = False
         self.startup_failed = False
         self.shutdown_failed = False
         self.should_exit = False
@@ -55,21 +55,21 @@ class LifespanOn:
         await self.receive_queue.put(startup_event)
         await self.startup_event.wait()
 
-        if self.startup_failed or (self.error_occured and self.config.lifespan == "on"):
+        if self.startup_failed or (self.error_occurred and self.config.lifespan == "on"):
             self.logger.error("Application startup failed. Exiting.")
             self.should_exit = True
         else:
             self.logger.info("Application startup complete.")
 
     async def shutdown(self) -> None:
-        if self.error_occured:
+        if self.error_occurred:
             return
         self.logger.info("Waiting for application shutdown.")
         shutdown_event: LifespanShutdownEvent = {"type": "lifespan.shutdown"}
         await self.receive_queue.put(shutdown_event)
         await self.shutdown_event.wait()
 
-        if self.shutdown_failed or (self.error_occured and self.config.lifespan == "on"):
+        if self.shutdown_failed or (self.error_occurred and self.config.lifespan == "on"):
             self.logger.error("Application shutdown failed. Exiting.")
             self.should_exit = True
         else:
@@ -86,7 +86,7 @@ class LifespanOn:
             await app(scope, self.receive, self.send)
         except BaseException as exc:
             self.asgi = None
-            self.error_occured = True
+            self.error_occurred = True
             if self.startup_failed or self.shutdown_failed:
                 return
             if self.config.lifespan == "auto":


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 🥲 -->

# Summary

Fix typo in variable name: `error_occured` → `error_occurred` in `LifespanOn` class.

## Changes
- `uvicorn/lifespan/on.py`: Fixed attribute name
- `tests/test_lifespan.py`: Updated test assertions

## Note
This changes a public attribute name on `LifespanOn` class.
I searched for external usage but couldn't find any code outside of uvicorn that accesses this attribute. However, please let me know if you have any concerns about backward compatibility.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.