### PR TITLE
Adds support for the `http.response.trailers` ASGI event.

### DIFF
--- a/docs/concepts/asgi.md
+++ b/docs/concepts/asgi.md
@@ -171,7 +171,48 @@ async def app(scope, receive, send):
     })
 ```
 
----
+### Sending trailers
+
+You can send trailing headers by indicating adding `"trailers": True` to the
+`http.response.start` message and sending `http.response.trailers` messages 
+after the body is completer.
+
+```python
+import asyncio
+
+
+async def app(scope, receive, send):
+    """
+    Send an HTTP response with headers and trailers.
+    """
+    await send({
+        'type': 'http.response.start',
+        'status': 200,
+        'headers': [
+            [b'content-type', b'text/plain'],
+        ],
+        "trailers": True
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': b'Hello, world!',
+    })
+    await send({
+        'type': 'http.response.trailers',
+        'body': b'',
+        'headers': [
+            [b'x-app-status', b'1'],
+        ],
+        'more_trailers': True
+    })
+    await send({
+        'type': 'http.response.trailers',
+        'body': b'',
+        'headers': [
+            [b'x-app-details', b'failed'],
+        ]
+    })
+```
 
 ## Why ASGI?
 


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

This borrows from the initial implementation by @Kludex as an extension library in
https://github.com/Kludex/uvicorn-extensions/tree/main/src/python/uvicorn-trailers/uvicorn_trailers but also implements it for h11 with some slight refactoring in approach.

This implements the trailers ASGI extension. This refactors the http implementations slightly into a more state-machine-like flow, since this now introduces a few more state transitions that are optional and/or could be continued. I maintained the original state attributes, since they were public, for backwards compatibility, but they could be removed if desired, since nothing in `uvicorn` strictly depends upon them that I
  can tell.

I generally made new attributes private, which is maybe stylistically-inconsistent, so happy to revert that if desired.

Fixes #1596 

# Checklist

- [ x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ x] I've updated the documentation accordingly.
