### PR TITLE
Revert "fix(websockets): Send close frame on ASGI return (#2769)"

### DIFF
--- a/tests/protocols/test_websocket.py
+++ b/tests/protocols/test_websocket.py
@@ -451,27 +451,6 @@ async def test_asgi_return_value(ws_protocol_cls: WSProtocol, http_protocol_cls:
         assert websocket.close_code == 1006
 
 
-async def test_close_transport_on_asgi_return(
-    ws_protocol_cls: WSProtocol, http_protocol_cls: HTTPProtocol, unused_tcp_port: int
-):
-    """The ASGI callable should call the `websocket.close` event.
-
-    If it doesn't, the server should still send a close frame to the client.
-    """
-
-    async def app(scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable):
-        message = await receive()
-        if message["type"] == "websocket.connect":
-            await send({"type": "websocket.accept"})
-
-    config = Config(app=app, ws=ws_protocol_cls, http=http_protocol_cls, lifespan="off", port=unused_tcp_port)
-    async with run_server(config):
-        async with websockets.client.connect(f"ws://127.0.0.1:{unused_tcp_port}") as websocket:
-            with pytest.raises(websockets.exceptions.ConnectionClosed):
-                await websocket.recv()
-        assert websocket.close_code == 1006
-
-
 @pytest.mark.parametrize("code", [None, 1000, 1001])
 @pytest.mark.parametrize("reason", [None, "test", False], ids=["none_as_reason", "normal_reason", "without_reason"])
 async def test_app_close(

--- a/uvicorn/protocols/websockets/websockets_impl.py
+++ b/uvicorn/protocols/websockets/websockets_impl.py
@@ -244,6 +244,7 @@ class WebSocketProtocol(WebSocketServerProtocol):
             result = await self.app(self.scope, self.asgi_receive, self.asgi_send)  # type: ignore[func-returns-value]
         except ClientDisconnected:  # pragma: full coverage
             self.closed_event.set()
+            self.transport.close()
         except BaseException:
             self.closed_event.set()
             self.logger.exception("Exception in ASGI application\n")
@@ -251,15 +252,17 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 self.send_500_response()
             else:
                 await self.handshake_completed_event.wait()
+            self.transport.close()
         else:
             self.closed_event.set()
             if not self.handshake_started_event.is_set():
                 self.logger.error("ASGI callable returned without sending handshake.")
                 self.send_500_response()
+                self.transport.close()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-            await self.handshake_completed_event.wait()
-        self.transport.close()
+                await self.handshake_completed_event.wait()
+                self.transport.close()
 
     async def asgi_send(self, message: ASGISendEvent) -> None:
         message_type = message["type"]

--- a/uvicorn/protocols/websockets/wsproto_impl.py
+++ b/uvicorn/protocols/websockets/wsproto_impl.py
@@ -234,17 +234,19 @@ class WSProtocol(asyncio.Protocol):
         try:
             result = await self.app(self.scope, self.receive, self.send)  # type: ignore[func-returns-value]
         except ClientDisconnected:
-            pass  # pragma: full coverage
+            self.transport.close()  # pragma: full coverage
         except BaseException:
             self.logger.exception("Exception in ASGI application\n")
             self.send_500_response()
+            self.transport.close()
         else:
             if not self.handshake_complete:
                 self.logger.error("ASGI callable returned without completing handshake.")
                 self.send_500_response()
+                self.transport.close()
             elif result is not None:
                 self.logger.error("ASGI callable should return None, but returned '%s'.", result)
-        self.transport.close()
+                self.transport.close()
 
     async def send(self, message: ASGISendEvent) -> None:
         await self.writable.wait()


### PR DESCRIPTION
```toml
  [project]                                                                                                          
  dependencies = [                                                                                                   
      "uvicorn @ git+https://github.com/encode/uvicorn@revert-websockets-closed",                                                 
  ]
```