### PR TITLE
Add TOML as another logging config format

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -82,7 +82,8 @@ Using Uvicorn with watchfiles will enable the following options (which are other
 
 ## Logging
 
-* `--log-config <path>` - Logging configuration file. **Options:** *`dictConfig()` formats: .json, .yaml*. Any other format will be processed with `fileConfig()`. Set the `formatters.default.use_colors` and `formatters.access.use_colors` values to override the auto-detected behavior.
+* `--log-config <path>` - Logging configuration file. **Options:** *`dictConfig()` formats: .json, .toml, .yaml*. Any other format will be processed with `fileConfig()`. Set the `formatters.default.use_colors` and `formatters.access.use_colors` values to override the auto-detected behavior.
+    * Using a TOML file for your logging config requires Python 3.11 or later.
     * If you wish to use a YAML file for your logging config, you will need to include PyYAML as a dependency for your project or install uvicorn with the `[standard]` optional extras.
 * `--log-level <str>` - Set the log level. **Options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.* **Default:** *'info'*.
 * `--no-access-log` - Disable access log only, without changing log level.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "a2wsgi==1.10.8",
     "wsproto==1.2.0",
     "websockets==13.1",
+    "tomli-w>=1.2.0",
 ]
 docs = [
     "mkdocs==1.6.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1456,6 +1456,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
 name = "trustme"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1557,6 +1566,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-xdist", extra = ["psutil"] },
     { name = "ruff" },
+    { name = "tomli-w" },
     { name = "trustme" },
     { name = "twine" },
     { name = "types-click" },
@@ -1600,6 +1610,7 @@ dev = [
     { name = "pytest-mock", specifier = "==3.14.0" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = "==3.6.1" },
     { name = "ruff", specifier = "==0.11.9" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "trustme", specifier = "==1.2.1" },
     { name = "twine", specifier = "==6.1.0" },
     { name = "types-click", specifier = "==7.1.8" },

--- a/uvicorn/config.py
+++ b/uvicorn/config.py
@@ -380,6 +380,12 @@ class Config:
                 with open(self.log_config) as file:
                     loaded_config = yaml.safe_load(file)
                     logging.config.dictConfig(loaded_config)
+            elif isinstance(self.log_config, str) and self.log_config.endswith(".toml"):  # pragma: py-lt-311
+                import tomllib
+
+                with open(self.log_config, "rb") as file:
+                    loaded_config = tomllib.load(file)
+                    logging.config.dictConfig(loaded_config)
             else:
                 # See the note about fileConfig() here:
                 # https://docs.python.org/3/library/logging.config.html#configuration-file-format

--- a/uvicorn/main.py
+++ b/uvicorn/main.py
@@ -200,7 +200,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: bool) -> No
     "--log-config",
     type=click.Path(exists=True),
     default=None,
-    help="Logging configuration file. Supported formats: .ini, .json, .yaml.",
+    help="Logging configuration file. Supported formats: .ini, .json, .toml, .yaml.",
     show_default=True,
 )
 @click.option(


### PR DESCRIPTION
# Summary

Allow the logging config to be loaded from a TOML file as an alternative to JSON and YAML.  Use `tomllib` from the standard library added with Python 3.11.

I find TOML easier to read and edit than JSON and YAML.  And it's closer to the native [configuration file format](https://docs.python.org/3/library/logging.config.html#logging-config-fileformat), while being easier to maintain as you don't have to separately list all loggers/handlers/formatters.

# Checklist

- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.