### PR TITLE
added possibility to run server on uds socket AND host/port pair

### DIFF
--- a/uvicorn/server.py
+++ b/uvicorn/server.py
@@ -156,9 +156,9 @@ class Server:
             os.chmod(config.uds, uds_perms)
             assert server.sockets is not None  # mypy
             listeners = server.sockets
-            self.servers = [server]
+            self.servers.append(server)
 
-        else:
+        if config.host is not None:
             # Standard case. Create a socket from a host/port pair.
             try:
                 server = await loop.create_server(
@@ -175,7 +175,7 @@ class Server:
 
             assert server.sockets is not None
             listeners = server.sockets
-            self.servers = [server]
+            self.servers.append(server)
 
         if sockets is None:
             self._log_started_message(listeners)


### PR DESCRIPTION
<!-- Thanks for contributing to Uvicorn! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary
this change is aimed to modify server startup function so it allows to listed incoming request both on uds socket and host/port pair. I saw many project when this is required. for example when Nginx is configured to redirect incoming request to uvicorn serving e.g. fastAPI via UDS socket and at the same time to serve host/port for internal microservices. 
this change is running on one of my projects for a while without any issues.  

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
