### PR TITLE
Fix X-Forwarded-For not properly handling ports

### DIFF
--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -11,7 +11,7 @@ from tests.response import Response
 from tests.utils import run_server
 from uvicorn._types import ASGIReceiveCallable, ASGISendCallable, Scope
 from uvicorn.config import Config
-from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware, _TrustedHosts
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware, _parse_host_port, _TrustedHosts
 
 if TYPE_CHECKING:
     from uvicorn.protocols.http.h11_impl import H11Protocol
@@ -496,8 +496,6 @@ async def test_proxy_headers_empty_x_forwarded_for() -> None:
 
 
 # --- Tests for X-Forwarded-For port handling (issue #2789) ---
-
-from uvicorn.middleware.proxy_headers import _parse_host_port
 
 
 @pytest.mark.parametrize(

--- a/tests/middleware/test_proxy_headers.py
+++ b/tests/middleware/test_proxy_headers.py
@@ -522,6 +522,8 @@ async def test_proxy_headers_empty_x_forwarded_for() -> None:
         ("", "", 0),
         # Malformed bracket
         ("[::1", "[::1", 0),
+        # Bracketed IPv6 with invalid port (non-numeric)
+        ("[::1]:abc", "::1", 0),
     ],
 )
 def test_parse_host_port(raw_entry: str, expected_host: str, expected_port: int) -> None:


### PR DESCRIPTION
## Summary

Fixes #2789.

- Add `_parse_host_port()` helper to properly extract host and port from `X-Forwarded-For` entries, handling IPv4 with port (`1.2.3.4:1024`), bracketed IPv6 with port (`[::1]:8080`), bare addresses, and edge cases
- Update `get_trusted_client_host()` to use the helper so trust checking works correctly for entries with ports (previously `1.2.3.4:1024` failed `ipaddress.ip_address()` and fell through to literal matching)
- Update `ProxyHeadersMiddleware.__call__()` to use the parsed port in `scope["client"]` instead of always hardcoding `0`

Before this fix, an `X-Forwarded-For` value of `1.2.3.4:1024` would produce `scope["client"] = ("1.2.3.4:1024", 0)`. After this fix, it correctly produces `scope["client"] = ("1.2.3.4", 1024)`.

## Test plan

- [x] All 248 existing proxy header tests continue to pass
- [x] Added 13 unit tests for `_parse_host_port()` covering IPv4, IPv4+port, bare IPv6, bracketed IPv6+port, edge cases
- [x] Added 8 integration tests for `X-Forwarded-For` with ports across trust scenarios (always trust, trusted proxy, untrusted proxy, multiple proxies, trusted networks)