### PR TITLE
Poll for readiness in `test_multiprocess_health_check` and `run_server`

### DIFF
--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -85,7 +85,7 @@ def test_multiprocess_health_check() -> None:
     process.kill()
     assert not process.is_alive()
     deadline = time.monotonic() + 10
-    while not all(p.is_alive() for p in supervisor.processes):
+    while not all(p.is_alive() for p in supervisor.processes):  # pragma: no cover
         assert time.monotonic() < deadline, "Timed out waiting for processes to be alive"
         time.sleep(0.1)
     supervisor.signal_queue.append(signal.SIGINT)

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -85,12 +85,9 @@ def test_multiprocess_health_check() -> None:
     process.kill()
     assert not process.is_alive()
     deadline = time.monotonic() + 10
-    while time.monotonic() < deadline:
-        if all(p.is_alive() for p in supervisor.processes):
-            break
+    while not all(p.is_alive() for p in supervisor.processes):
+        assert time.monotonic() < deadline, "Timed out waiting for processes to be alive"
         time.sleep(0.1)
-    for p in supervisor.processes:
-        assert p.is_alive()
     supervisor.signal_queue.append(signal.SIGINT)
     supervisor.join_all()
 

--- a/tests/supervisors/test_multiprocess.py
+++ b/tests/supervisors/test_multiprocess.py
@@ -84,7 +84,11 @@ def test_multiprocess_health_check() -> None:
     process = supervisor.processes[0]
     process.kill()
     assert not process.is_alive()
-    time.sleep(1)
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if all(p.is_alive() for p in supervisor.processes):
+            break
+        time.sleep(0.1)
     for p in supervisor.processes:
         assert p.is_alive()
     supervisor.signal_queue.append(signal.SIGINT)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,8 @@ from uvicorn import Config, Server
 async def run_server(config: Config, sockets: list[socket] | None = None) -> AsyncIterator[Server]:
     server = Server(config=config)
     task = asyncio.create_task(server.serve(sockets=sockets))
-    await asyncio.sleep(0.1)
+    while not server.started:
+        await asyncio.sleep(0.05)
     try:
         yield server
     finally:


### PR DESCRIPTION
## Summary

- **`test_multiprocess_health_check`**: Replace fixed `time.sleep(1)` with a polling loop that waits until all processes are alive (same pattern as #2815 applied to `test_multiprocess_sighup`).
- **`run_server` test helper**: Wait for `server.started` instead of a fixed `asyncio.sleep(0.1)`, avoiding connection races on slow setups (e.g. free-threaded Python 3.14 on macOS).

Both failures were observed in the CI run for #2815: https://github.com/Kludex/uvicorn/actions/runs/22040348497/job/63680100568

## Test plan

- [ ] CI passes on `Python 3.14t macos-latest` (the previously failing matrix entry)