### PR TITLE
Ignore permission denied errors in watchfiles reloader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ standard = [
     "python-dotenv>=0.13",
     "PyYAML>=5.1",
     "uvloop>=0.15.1; sys_platform != 'win32' and (sys_platform != 'cygwin' and platform_python_implementation != 'PyPy')",
-    "watchfiles>=0.13",
+    "watchfiles>=0.20",
     "websockets>=10.4",
 ]
 

--- a/uvicorn/supervisors/watchfilesreload.py
+++ b/uvicorn/supervisors/watchfilesreload.py
@@ -61,7 +61,7 @@ class WatchFilesReload(BaseReload):
     ) -> None:
         super().__init__(config, target, sockets)
         self.reloader_name = "WatchFiles"
-        self.reload_dirs = []
+        self.reload_dirs: list[Path] = []
         for directory in config.reload_dirs:
             self.reload_dirs.append(directory)
 
@@ -73,6 +73,7 @@ class WatchFilesReload(BaseReload):
             # using yield_on_timeout here mostly to make sure tests don't
             # hang forever, won't affect the class's behavior
             yield_on_timeout=True,
+            ignore_permission_denied=True,
         )
 
     def should_restart(self) -> list[Path] | None:


### PR DESCRIPTION
- Pass `ignore_permission_denied=True` to `watchfiles.watch()` so directories the process cannot access are silently skipped instead of crashing the reloader.
- Bump minimum `watchfiles` version from `>=0.13` to `>=0.20` (the release that introduced the parameter, from August 2023).

---

- Closes #1785