### PR TITLE
Use `context=` kwarg on `loop.create_task` for Python 3.11+

### DIFF
--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -226,7 +226,7 @@ class MockLoop:
         self._tasks: list[asyncio.Task[Any]] = []
         self._later: list[MockTimerHandle] = []
 
-    def create_task(self, coroutine: Any) -> Any:
+    def create_task(self, coroutine: Any, **kwargs: Any) -> Any:
         self._tasks.insert(0, coroutine)
         return MockTask()
 

--- a/tests/protocols/test_http.py
+++ b/tests/protocols/test_http.py
@@ -226,7 +226,7 @@ class MockLoop:
         self._tasks: list[asyncio.Task[Any]] = []
         self._later: list[MockTimerHandle] = []
 
-    def create_task(self, coroutine: Any, **kwargs: Any) -> Any:
+    def create_task(self, coroutine: Any) -> Any:
         self._tasks.insert(0, coroutine)
         return MockTask()
 


### PR DESCRIPTION
## Summary
- On Python 3.11+, pass `context=contextvars.Context()` directly to `loop.create_task` instead of using `Context().run(loop.create_task, ...)`. This was already noted as a TODO.
- Falls back to `Context().run()` on Python 3.10.

## Context
Investigating #2794. Could not reproduce the memory leak on Python 3.13.11/Linux with ALB-like traffic patterns (50k requests, abrupt closes, concurrent connections), but this change avoids the `Context.run()` indirection which may behave differently under certain workloads.

## Test plan
- [ ] All existing HTTP protocol tests pass (128/128)
- [ ] Reporter from #2794 tests with this branch to check if it resolves their memory leak