### PR TITLE
Ensure WSGI SERVER_PORT is a string per PEP 3333

### DIFF
--- a/uvicorn/middleware/wsgi.py
+++ b/uvicorn/middleware/wsgi.py
@@ -52,7 +52,7 @@ def build_environ(scope: HTTPScope, message: ASGIReceiveEvent, body: io.BytesIO)
     if server is None:
         server = ("localhost", 80)
     environ["SERVER_NAME"] = server[0]
-    environ["SERVER_PORT"] = server[1]
+    environ["SERVER_PORT"] = str(server[1]) if server[1] is not None else ""
 
     # Get client IP address
     client = scope.get("client")


### PR DESCRIPTION
The WSGI middleware sets `SERVER_PORT` directly from the ASGI scope's server tuple:

```python
environ["SERVER_PORT"] = server[1]
```

`server[1]` is `int | None` in the ASGI spec, but PEP 3333 requires all CGI variables to be strings. WSGI apps or frameworks that do string operations on `SERVER_PORT` (e.g., concatenation) would get a `TypeError`.

Additionally, when serving over a Unix domain socket, the ASGI scope can have `server = ("path", None)`, which would set `SERVER_PORT = None`.

This converts the port to a string, falling back to an empty string when the port is `None`.
