### PR TITLE
Add `cooldown` setting to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       python-packages:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

- Add `cooldown: default-days: 7` to both `uv` and `github-actions` ecosystems in `.github/dependabot.yml`.
- Resolves the two open `zizmor/dependabot-cooldown` code scanning alerts.