### PR TITLE
Fix CodSpeed action ref-version mismatch

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2 # v4
+        uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30 # v4
         with:
           mode: instrumentation
           run: uv run pytest tests/benchmarks/ --codspeed -n 0


### PR DESCRIPTION
## Summary
- update the pinned `CodSpeedHQ/action` commit in `.github/workflows/benchmark.yml`
- align the SHA with the `# v4` version comment to resolve the `zizmor/ref-version-mismatch` code-scanning alert

## Why
The workflow referenced `CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2` while annotating it as `# v4`, but the current `v4` tag resolves to `db35df748deb45fdef0960669f57d627c1956c30`.

## Validation
- verified the alert details via `gh api repos/Kludex/uvicorn/code-scanning/alerts/5`
- resolved the `v4` tag target via the GitHub API and updated the workflow pin accordingly
